### PR TITLE
Add context to 'Maintenance' string to differentiate from plugin name

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -3,7 +3,7 @@
 
 	function maintenance_admin_setup() {
 		global	$maintenance_variable;
-				$maintenance_variable->options_page = add_menu_page( __( 'Maintenance', 'maintenance' ), __( 'Maintenance', 'maintenance' ), 'manage_options', 'maintenance', 'manage_options',  MAINTENANCE_URI . '/images/icon-small.png');
+				$maintenance_variable->options_page = add_menu_page( _x( 'Maintenance', 'Admin screen title', 'maintenance' ), _x( 'Maintenance', 'Admin screen title', 'maintenance' ), 'manage_options', 'maintenance', 'manage_options',  MAINTENANCE_URI . '/images/icon-small.png');
 
 		add_action( "admin_init", 'mt_register_settings');
 		add_action( "admin_head-{$maintenance_variable->options_page}", 'maintenance_metaboxes_scripts' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -671,7 +671,7 @@ function maintenance_add_toolbar_items(){
     } else {
         $check = 'Off';
     }
-    $wp_admin_bar->add_menu( array( 'id' => 'maintenance_options', 'title' => __( 'Maintenance', 'maintenance' ) . __( ' is ', 'maintenance' ) . $check, 'href' => $url_to, 'meta'  => array( 'title' => __( 'Maintenance', 'maintenance' ) . __( ' is ', 'maintenance' ) . $check)));
+		$wp_admin_bar->add_menu( array( 'id' => 'maintenance_options', 'title' => _x( 'Maintenance', 'Admin screen title', 'maintenance' ) . __( ' is ', 'maintenance' ) . $check, 'href' => $url_to, 'meta'  => array( 'title' => _x( 'Maintenance', 'Admin screen title', 'maintenance' ) . __( ' is ', 'maintenance' ) . $check)));	
 }
 
 


### PR DESCRIPTION
As menu and page title can be translated, the plugin name should be kept untouched for reputation and referencing across the web.
Adding context to this strings helps to differentiate both plugin name and 'Maintenance' titles where it is necessary.